### PR TITLE
v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm install -S altnode.dc-node
 ```
 
 ## API
-### AudioNode
+### DCNode
 - `constructor(audioContext: AudioContext, value = 0)`
 
 #### Instance attributes

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "altnode.dc-node",
   "description": "altnode.DCNode",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Nao Yonamine <mohayonao@gmail.com>",
   "bugs": {
-    "url": "https://github.com/altnode/feedback-delay-node/issues"
+    "url": "https://github.com/altnode/dc-node/issues"
   },
   "dependencies": {
     "altnode.alt-audio-node": "^0.2.0"
@@ -26,7 +26,7 @@
     "index.js",
     "lib"
   ],
-  "homepage": "https://github.com/altnode/feedback-delay-node",
+  "homepage": "https://github.com/altnode/dc-node",
   "keywords": [
     "Web Audio API"
   ],
@@ -34,7 +34,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/altnode/feedback-delay-node.git"
+    "url": "https://github.com/altnode/dc-node.git"
   },
   "scripts": {
     "build": "babel src --out-dir lib",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/altnode/feedback-delay-node/issues"
   },
   "dependencies": {
-    "altnode.audio-node": "^0.1.1"
+    "altnode.alt-audio-node": "^0.2.0"
   },
   "devDependencies": {
     "babel": "^5.8.23",

--- a/src/DCNode.js
+++ b/src/DCNode.js
@@ -1,8 +1,8 @@
-import AudioNode from "altnode.audio-node";
+import AltAudioNode from "altnode.alt-audio-node";
 import { VALUE, BUFSRC } from "./symbols";
 import createDCBuffer from "./createDCBuffer";
 
-export default class DCNode extends AudioNode {
+export default class DCNode extends AltAudioNode {
   constructor(audioContext, value = 0) {
     super(audioContext);
 


### PR DESCRIPTION
- use `altnode.AltAudioNode` instead of `altnode.AudioNode`
